### PR TITLE
Remove error prone local and add tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Variables
  - `ordered_cache_behavior_variables`: Mandatory. Default values has been set on `variables.tf`
  - `waf_web_acl_id`: Optional. If provided it will be used and attached to distribution
  - `acm_certificate_arn_config`: Optional. If nothing is specified it goes to the default certificate. Viewer Certificate Arguments
+ - `tags`: Optional. Tags added to cloudfront distribution
 
 Examples
 --------

--- a/locals.tf
+++ b/locals.tf
@@ -1,10 +1,3 @@
-# ID
-
-locals {
-  origin_id        = "${var.origin_id != "" ? var.origin_id : "S3-${var.app_name}-${var.role}-${var.environment}"}"
-  target_origin_id = "${var.target_origin_id != "" ? var.target_origin_id : var.origin_id}"
-}
-
 # Logging config enabled
 locals {
   cloudfront_logging_configs = {

--- a/main.tf
+++ b/main.tf
@@ -139,15 +139,15 @@ resource "aws_cloudfront_distribution" "cf_distribution" {
   }
 
   # Optional certificate
-    dynamic "viewer_certificate" {
-      for_each = local.acm_certificate_arn_configs[local.enable_certificate]
-      content {
-        acm_certificate_arn            = viewer_certificate.value.acm_certificate_arn
-        minimum_protocol_version       = viewer_certificate.value.minimum_protocol_version
-        ssl_support_method             = viewer_certificate.value.ssl_support_method
-        cloudfront_default_certificate = viewer_certificate.value.cloudfront_default_certificate
-      }
+  dynamic "viewer_certificate" {
+    for_each = local.acm_certificate_arn_configs[local.enable_certificate]
+    content {
+      acm_certificate_arn            = viewer_certificate.value.acm_certificate_arn
+      minimum_protocol_version       = viewer_certificate.value.minimum_protocol_version
+      ssl_support_method             = viewer_certificate.value.ssl_support_method
+      cloudfront_default_certificate = viewer_certificate.value.cloudfront_default_certificate
     }
+  }
 
   web_acl_id = var.waf_web_acl_id
 }

--- a/main.tf
+++ b/main.tf
@@ -150,4 +150,6 @@ resource "aws_cloudfront_distribution" "cf_distribution" {
   }
 
   web_acl_id = var.waf_web_acl_id
+
+  tags = "${var.tags}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,9 @@ variable "acm_certificate_arn_config" {
     ssl_support_method       = "sni-only"
   }
 }
+
+variable "tags" {
+  description = "A map of tags to add to your cloudfront distribution"
+  default     = {}
+  type        = map
+}


### PR DESCRIPTION
The local caused an error about the variable var.origin_id not being defined.

Also added in support for tags.